### PR TITLE
Remove VOLUME

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -9,10 +9,6 @@ ENV JENKINS_HOME /var/jenkins_home
 # ensure you use same uid
 RUN useradd -d "$JENKINS_HOME" -u 1000 -m -s /bin/bash jenkins
 
-# Jenkins home directoy is a volume, so configuration and build history 
-# can be persisted and survive image upgrades
-VOLUME /var/jenkins_home
-
 # `/usr/share/jenkins/ref/` contains all reference configuration we want 
 # to set on a fresh new installation. Use it to bundle additional plugins 
 # or config file with your custom jenkins Docker image.


### PR DESCRIPTION
The end-user should be left to determine if they want to bake configs into the image or use a volume. 

While I understand that the $JENKINS_HOME variable can be used to override the directory in child images, this is not conventional in official images on Docker Hub. Official builds are often used as immutable building blocks for other containers and those containers are where the determination of storage should be made. Even if a child image is not made, a user can easily specify a volume on the command-line for storing state outside of a container.

Additionally, if a user does not look at the Dockerfile or documentation properly they could leave orphaned volumes laying around when they remove the container.