### PR TITLE
add ajp connection to expose from docker container

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -33,6 +33,9 @@ RUN chown -R jenkins "$JENKINS_HOME" /usr/share/jenkins/ref
 # for main web interface:
 EXPOSE 8080
 
+# for ajp interface:
+EXPOSE 8009
+
 # will be used by attached slave agents:
 EXPOSE 50000
 


### PR DESCRIPTION
This should add the ajp connection to allow apache to talk to jenkins in docker.