### PR TITLE
Ignore comments and empty lines in plugins file

### DIFF
--- a/plugins.sh
+++ b/plugins.sh
@@ -13,5 +13,7 @@ mkdir -p $REF
 
 while read spec; do
     plugin=(${spec//:/ }); 
+    [[ ${plugin[0]} =~ ^# ]] && continue
+    [[ ${plugin[0]} =~ ^\s*$ ]] && continue
     curl -L ${JENKINS_UC}/download/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.hpi;
 done  < $1


### PR DESCRIPTION
I made a small change to <code>plugins.sh</code> to be able to add empty lines and comments to a plugin spec file. This helps maintaining them and keeping them organized. I'd appreciate it if you would consider including it.

Best regards,

Manuel
