### PR TITLE
fix Dockfile error: A # marker anywhere else in the line will be treated...

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ You can run your container as root - and unstall via apt-get, install as part of
 
 ```
 FROM jenkins
-USER root # if we want to install via apt
+# if we want to install via apt
+USER root
 RUN apt-get install -y ruby make more-thing-here
 USER jenkins # drop back to the regular jenkins user - good practice
 ```


### PR DESCRIPTION
Docker will treat lines that begin with # as a comment. A # marker anywhere else in the line will be treated as an argument.  So # comments inline are not supported by Dockerfile.